### PR TITLE
Add support for binary sensors with 'gas' device class (#164)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Here's a list of the devices that are currently exposed:
 
 ### Binary Sensor Support
 
-Binary Sensors must have a `device_class` set. Accepted `device_class`es are `moisture`, `motion`, `occupancy`, `opening` and `smoke`.
+Binary Sensors must have a `device_class` set. Accepted `device_class`es are `gas`, `moisture`, `motion`, `occupancy`, `opening` and `smoke`.
+
+For binary sensors with the `gas` `device_class` you can also set `homebridge_gas_type` to `co` or `co2` or to control how the entity is shown in Homebridge (`co` is default).
 
 For binary sensors with the `opening` `device_class` you can also set `homebridge_opening_type` to `window` to have the entity display as a window instead of a door to Homebridge.
 

--- a/accessories/binary_sensor.js
+++ b/accessories/binary_sensor.js
@@ -71,6 +71,34 @@ function HomeAssistantBinarySensorFactory(log, data, client) {
     return null;
   }
   switch (data.attributes.device_class) {
+    case 'gas':
+      if (!(data.attributes.homebridge_gas_type)) {
+        return new HomeAssistantBinarySensor(log, data, client,
+                                             Service.CarbonMonoxideSensor,
+                                             Characteristic.CarbonMonoxideDetected,
+                                             Characteristic.LeakDetected.CO_LEVELS_ABNORMAL,
+                                             Characteristic.LeakDetected.CO_LEVELS_NORMAL);
+      }
+      switch (data.attributes.homebridge_gas_type) {
+        case 'co2':
+          return new HomeAssistantBinarySensor(log, data, client,
+                                               Service.CarbonDioxideSensor,
+                                               Characteristic.CarbonDioxideDetected,
+                                               Characteristic.LeakDetected.CO2_LEVELS_ABNORMAL,
+                                               Characteristic.LeakDetected.CO2_LEVELS_NORMAL);
+        case 'co':
+          return new HomeAssistantBinarySensor(log, data, client,
+                                               Service.CarbonMonoxideSensor,
+                                               Characteristic.CarbonMonoxideDetected,
+                                               Characteristic.LeakDetected.CO_LEVELS_ABNORMAL,
+                                               Characteristic.LeakDetected.CO_LEVELS_NORMAL);
+        default:
+          return new HomeAssistantBinarySensor(log, data, client,
+                                               Service.CarbonMonoxideSensor,
+                                               Characteristic.CarbonMonoxideDetected,
+                                               Characteristic.LeakDetected.CO_LEVELS_ABNORMAL,
+                                               Characteristic.LeakDetected.CO_LEVELS_NORMAL);
+      }
     case 'moisture':
       return new HomeAssistantBinarySensor(log, data, client,
                                            Service.LeakSensor,
@@ -103,7 +131,7 @@ function HomeAssistantBinarySensorFactory(log, data, client) {
                                            Characteristic.SmokeDetected.SMOKE_NOT_DETECTED);
     default:
       log.error(`'${data.entity_id}' has a device_class of '${data.attributes.device_class}' which is not supported by ` +
-                'homebridge-homeassistant. Supported classes are \'moisture\', \'motion\', \'occupancy\', \'opening\' and \'smoke\'. ' +
+                'homebridge-homeassistant. Supported classes are \'gas\', \'moisture\', \'motion\', \'occupancy\', \'opening\' and \'smoke\'. ' +
                 'See the README.md for more information.');
       return null;
   }


### PR DESCRIPTION
* Update README.md

Add 'homebridge_gas_type" description.

* Update binary_sensor.js

Add compatibility for 'gas' type of 'device_class'

* Specify that 'co' is default for gas binary sensor

* Clean up formatting before merging